### PR TITLE
get json from flask.helpers

### DIFF
--- a/flaskext/gae_mini_profiler/profiler.py
+++ b/flaskext/gae_mini_profiler/profiler.py
@@ -8,10 +8,10 @@
 """
 
 import datetime
+from flask.helpers import json
 import os
 import pickle
 import re
-import simplejson
 import StringIO
 from types import GeneratorType
 import zlib
@@ -54,7 +54,7 @@ class RequestStatsHandler(RequestHandler):
                     request_stats.disabled = True
                     request_stats.store()
 
-        self.response.out.write(simplejson.dumps(list_request_stats))
+        self.response.out.write(json.dumps(list_request_stats))
 
 class RequestStats(object):
 


### PR DESCRIPTION
Just tested my app using the new python27 runtime on Google App Engine and got an error because gae_mini_profiler tries to import simplejson directly (see http://i.imgur.com/1a9B3.png). flask.helpers exports a json module to protect against exactly this situation.
